### PR TITLE
Added the launchtime after the launchdate

### DIFF
--- a/lib/views/launchdetails/launch_detail_body.dart
+++ b/lib/views/launchdetails/launch_detail_body.dart
@@ -58,7 +58,7 @@ class LaunchDetailBodyState extends State<LaunchDetailBodyWidget> {
           child: new Padding(
             padding: const EdgeInsets.only(left: 8.0),
             child: new Text(
-              new DateFormat.yMMMMEEEEd().format(mLaunch.net),
+              new DateFormat.yMMMMEEEEd().add_Hms().format(mLaunch.net),
               maxLines: 2,
               style: textTheme.subhead.copyWith(color: Colors.white70),
               overflow: TextOverflow.fade,


### PR DESCRIPTION
Added the launchtime in 24H format. Replace `add_Hms()` with `add_jms()` to use 12H format.

Trying to start the app in the simulator failed, but I think this is the only thing that should happen for the launchtime to show in the app. Testing is still advised though :p