### PR TITLE
Updated the landing icon

### DIFF
--- a/lib/views/launchdetails/launch_detail_body.dart
+++ b/lib/views/launchdetails/launch_detail_body.dart
@@ -154,7 +154,6 @@ class LaunchDetailBodyState extends State<LaunchDetailBodyWidget> {
               children: <Widget>[
                 new Icon(
                   Icons.flight_land,
-                  color: Colors.white,
                 ),
                 new Expanded(
                   child: new Padding(


### PR DESCRIPTION
It was white on white. Now it should follow the other icons (not tested, as I don't have the config)